### PR TITLE
Upgraded NumPy version to support >=1.26,<3 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "argparse",
     "pyyaml",
-	  "numpy==1.24.2",
+	  "numpy>=1.26,<3",
 ]
 
 [project.urls]

--- a/src/torch_bp/bp/svbp.py
+++ b/src/torch_bp/bp/svbp.py
@@ -616,7 +616,7 @@ class LoopySVBP(SVBP):
         # log_msgs[s, t] is log(msg_{s -> t})
         if self.msg_init_mode == "uniform":
             self.log_msgs = [
-                [torch.log(torch.ones(self.K, dtype=torch.float32) / self.K)
+                [torch.log(torch.ones(self.K, **self.tensor_kwargs) / self.K)
                  for n in self.graph.get_nbrs(node)]
                 for node in range(self.graph.N)
             ]


### PR DESCRIPTION
Changed numpy==1.24.2 to numpy>=1.26,<3 to prevent conflicts with libraries that require NumPy ≥1.26 (e.g. JAX, SciPy).
Changed LoopySVBP.reset_msgs() to ensure the messages are created on the same device.
